### PR TITLE
feat(cli): allow loading additional languages when checking

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ export interface VerifyOptions {
   buildDir?: string
   contentDir?: string
   watch?: boolean
+  languages?: string
 }
 
 let currentFile = ''
@@ -143,8 +144,12 @@ export async function verify(options: VerifyOptions = {}) {
     },
   )
 
+  const additionalLanguages = options.languages?.split(',').map(l => l.trim()) || []
   const highlighter = await getSingletonHighlighter()
-  await highlighter.loadLanguage('js')
+  await Promise.all([
+    highlighter.loadLanguage('js'),
+    ...additionalLanguages.map(lang => highlighter.loadLanguage(lang)),
+  ])
 
   console.log('Verifying Twoslash in', markdownFiles.length, 'files...')
   console.log(markdownFiles.map(f => `  - ${relative(realCwd, f)}`).join('\n'))
@@ -202,6 +207,7 @@ cli.command('verify', 'Verify twoslash code blocks in markdown files')
   .option('--build-dir <dir>', 'The build directory of the Nuxt project')
   .option('--content-dir <dir>', 'The content directory of the Nuxt project')
   .option('--root-dir <dir>', 'The root directory of the Nuxt project')
+  .option('--languages <langs>', 'Additional languages to load (comma-separated)')
   .option('--resolve-nuxt', 'Resolve Nuxt project', { default: false })
   .option('-w, --watch', 'Watch files', { default: false })
   .action((args) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This allows specifying additional languages (such as `html`) to load when running the CLI

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
