### PR TITLE
fix: replace CommonJS requires in runtime mdc config

### DIFF
--- a/src/runtime/mdc-config.js
+++ b/src/runtime/mdc-config.js
@@ -2,6 +2,8 @@
 
 import process from 'node:process'
 import { defineConfig } from '@nuxtjs/mdc/config'
+import picomatch from 'picomatch'
+import { visit } from 'unist-util-visit'
 
 async function fallback() {
   const { removeTwoslashNotations } = await import('twoslash/fallback')
@@ -27,7 +29,6 @@ function resolveFileContext(filename, contextConfigs) {
   if (!filename)
     return undefined
 
-  const picomatch = require('picomatch')
   const relativePath = `../${filename}`
 
   for (const contextName of CONTEXT_PRIORITY) {
@@ -55,9 +56,6 @@ export default defineConfig({
       // It encodes [filename] (already parsed by MDC into properties.filename)
       // back into the meta string so the shiki transformer can access it.
       return processor.use(() => (/** @type {any} */ tree) => {
-        const { visit } = /** @type {typeof import('unist-util-visit')} */ (
-          require('unist-util-visit')
-        )
         visit(tree, 'element', (/** @type {any} */ node) => {
           if (node.tagName === 'pre' && node.properties?.filename) {
             const filename = node.properties.filename


### PR DESCRIPTION
Replace the remaining CommonJS `require(...)` calls in `src/runtime/mdc-config.js` with ESM imports.

I kept the larger Twoslash modules on async imports. `picomatch` and `unist-util-visit` are small synchronous helpers in an ESM-only file, so static ESM importsshould not materially affect bundle size.

## StackBlitz
- Bug: [twoslash-52](https://stackblitz.com/github/onmax/repros/tree/main/twoslash-52?startScript=verify)
- Fix: [twoslash-52-fix](https://stackblitz.com/github/onmax/repros/tree/main/twoslash-52-fix?startScript=verify)

## Verify
```bash
pnpm lint
pnpm build
pnpm test:unit
```